### PR TITLE
Fix crontab example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Using Hosts data from [repo 'GitHub520'](https://github.com/521xueweihan/GitHub5
 
 On Windows, you can add `pythonw X:\path\to\update_gh_hosts.py` to your [Windows Task Schedule]
 
-On a Unix-like OS, you can add `* */2 * * * /path/to/update_gh_hosts.py` to root crontab
+On a Unix-like OS, you can add `@hourly /path/to/update_gh_hosts.py` to root crontab


### PR DESCRIPTION
Sorry for the mistake in the crontab example, which I thought would run every 2 hours, but actually runs every minute. That's too frequently. Now I modify it to `@hourly`, as recommended [here](https://github.com/521xueweihan/GitHub520#22-%E8%87%AA%E5%8A%A8%E6%96%B9%E5%BC%8F), in a way that is easier to understand.